### PR TITLE
Add a CI workflow stub (#1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,10 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Hello world'


### PR DESCRIPTION
Having a stub file on the default branch, with `workflow_dispatch` specified as a trigger, will help with testing the workflow while building it out on another branch.