### PR TITLE
Bump `bhx5chain` version

### DIFF
--- a/bh-jws-utils/CHANGELOG.md
+++ b/bh-jws-utils/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+### Changed
+
 - The `bhx5chain` dependency is bumped to version `0.2` (from `0.1`).
 
 ## [0.1.0] - 2025-04-01

--- a/bh-jws-utils/CHANGELOG.md
+++ b/bh-jws-utils/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+- The `bhx5chain` dependency is bumped to version `0.2` (from `0.1`).
+
 ## [0.1.0] - 2025-04-01
 
 ### Added

--- a/bh-jws-utils/Cargo.toml
+++ b/bh-jws-utils/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/blockhousetech/eudi-rust-core"
 [dependencies]
 base64 = "0.21.7"
 bherror = "0.1"
-bhx5chain = "0.1"
+bhx5chain = "0.2"
 iref = "3.2"
 # `jwt` crate supports cryptography backend injection for signing/verification
 # via traits, unlike the much more popular `jsonwebtoken`


### PR DESCRIPTION
In the `bh-jws-utils` crate, the `bhx5chain` dependency version is bumped to `0.2` from `0.1`.