### PR TITLE
Relax length check for public key coordinates in JWT verification

### DIFF
--- a/bh-jws-utils/CHANGELOG.md
+++ b/bh-jws-utils/CHANGELOG.md
@@ -12,6 +12,14 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 - The `bhx5chain` dependency is bumped to version `0.2` (from `0.1`).
 
+### Fixed
+
+- The `verify_jwt_signature` function now performs a more relaxed
+  check on the length of the public key coordinates.
+  Previously, it required the coordinates to be exactly 32 bytes.
+  This has been updated to allow lengths of **32 bytes or less**.
+
+
 ## [0.1.0] - 2025-04-01
 
 ### Added

--- a/bh-jws-utils/CHANGELOG.md
+++ b/bh-jws-utils/CHANGELOG.md
@@ -14,10 +14,10 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ### Fixed
 
-- The `verify_jwt_signature` function now performs a more relaxed
-  check on the length of the public key coordinates.
-  Previously, it required the coordinates to be exactly 32 bytes.
-  This has been updated to allow lengths of **32 bytes or less**.
+- The `verify_jwt_signature` function now performs a more relaxed check on the
+  length of the public key coordinates. Previously, it required the coordinates
+  to be exactly 32 bytes. This has been updated to allow lengths of **32 bytes
+  or less**.
 
 
 ## [0.1.0] - 2025-04-01


### PR DESCRIPTION
In practice, the public key coordinates (x and y) of an elliptic curve key may be shorter than 32 bytes due to leading zeros being omitted during encoding. Strictly requiring the coordinates to be exactly 32 bytes can lead to compatibility issues with third-party libraries or systems that produce valid keys with shorter lengths.