### PR TITLE
Set up git user/email when tagging the crate release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,8 @@ jobs:
 
       - name: Tag the Release
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -afm "Release ${RELEASE_TAG}" "${RELEASE_TAG}" "${GIT_CHECKOUT_REF}"
           git push ${DRY_RUN_FLAG} origin "${RELEASE_TAG}"
 


### PR DESCRIPTION
While running on github-hosted runners, it's necessary to manually set up git user/email (https://github.com/actions/checkout/issues/13) for the time being.

The user/email used was taken from a suggestion in `actions/checkout` README:
https://github.com/actions/checkout/blob/main/README.md#push-a-commit-using-the-built-in-token