### PR TITLE
Add `public_jwk` method to the `Signer` trait

### DIFF
--- a/bh-jws-utils/CHANGELOG.md
+++ b/bh-jws-utils/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+### Added
+
+- The `public_jwk` method on the `Signer` `trait` that exposes the public key of
+  the respective implementer in the JWK format.
+
 ## [0.2.0] - 2025-04-09
 
 ### Changed

--- a/bh-jws-utils/src/traits.rs
+++ b/bh-jws-utils/src/traits.rs
@@ -151,6 +151,9 @@ pub trait Signer {
     ///
     /// The `message` is guaranteed to be a valid JWS signing input.
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, BoxError>;
+
+    /// The public key of the respective [`Signer`] in the JWK format.
+    fn public_jwk(&self) -> Result<JwkPublic, BoxError>;
 }
 
 /// Subtrait for [`Signer`]-s which have an associated JWK `kid` (Key ID) parameter.


### PR DESCRIPTION
In the `bh-jws-utils` crate, the `Signer` trait is extended with the `public_jwk` method that exposes the public key of the respective signer in the JWK format.