### PR TITLE
Verify the `mdoc` Device Public Key on `present`

### DIFF
--- a/bhmdoc/CHANGELOG.md
+++ b/bhmdoc/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 - The `Verifier` can now optionally verify the Issuer's authenticity.
 - `Claims` now implements `Debug`, `Clone`, and `PartialEq`.
+- The _mdoc_ Device `Signer` must now match the `DeviceKey` signed by
+the Issuer.
 
 ## [0.1.0] - 2025-04-22
 

--- a/bhmdoc/CHANGELOG.md
+++ b/bhmdoc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-04-24
+
 ### Added
 
 - The `Verifier` can now optionally verify the Issuer's authenticity.
@@ -24,5 +26,6 @@ the Issuer.
 - README.md describing the crate.
 - Initial version of the `bhmdoc` crate.
 
-[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bhmdoc/v0.1.0...HEAD>
+[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bhmdoc/v0.2.0...HEAD>
+[0.2.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bhmdoc/v0.2.0>
 [0.1.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bhmdoc/v0.1.0>

--- a/bhmdoc/Cargo.toml
+++ b/bhmdoc/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/blockhousetech/eudi-rust-core"
 
 [dependencies]
 base64 = "0.21"
-bh-jws-utils = "0.2"
+bh-jws-utils = "0.3"
 bherror = "0.1"
 bhx5chain = "0.2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/bhmdoc/Cargo.toml
+++ b/bhmdoc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bhmdoc"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for handling mDL/mdoc specification."

--- a/bhmdoc/src/error.rs
+++ b/bhmdoc/src/error.rs
@@ -101,6 +101,9 @@ pub enum MdocError {
     /// timestamp.
     #[strum(to_string = "{0} seconds overflows time")]
     InvalidTime(u64),
+    /// The provided Device [`Signer`][bh_jws_utils::Signer] is invalid.
+    #[strum(to_string = "Invalid Device Signer: {0}")]
+    InvalidDeviceSigner(String),
 }
 
 impl bherror::BhError for MdocError {}

--- a/bhmdoc/src/models/data_retrieval/device_retrieval/issuer_auth.rs
+++ b/bhmdoc/src/models/data_retrieval/device_retrieval/issuer_auth.rs
@@ -33,7 +33,7 @@ use bherror::traits::{
 use bhx5chain::{X509Trust, X5Chain};
 use coset::{
     iana::{EnumI64 as _, HeaderParameter},
-    Algorithm, CoseKey, Header, Label, RegisteredLabelWithPrivate,
+    Algorithm, CborOrdering, CoseKey, Header, Label, RegisteredLabelWithPrivate,
 };
 
 use super::response::{DigestID, IssuerNameSpaces, IssuerSignedItemBytes};
@@ -610,6 +610,13 @@ impl DeviceKey {
     /// Returns a JWK representation of the underlying `COSE_Key`.
     pub fn as_jwk(&self) -> Result<serde_json::Map<String, serde_json::Value>> {
         cose_key_to_jwk(&self.0)
+    }
+
+    /// Re-order the contents of the key lexicographically, as per
+    /// `Section 4.2.1` of the `RFC 8949` (_Core Deterministic Encoding
+    /// Requirements_).
+    pub(crate) fn canonicalize(&mut self) {
+        self.0.canonicalize(CborOrdering::Lexicographic);
     }
 }
 

--- a/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
+++ b/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
@@ -179,7 +179,7 @@ impl Document {
             .verify_signature(trust, &get_signature_verifier)
             .ctx(|| "issuer signature")?;
 
-        let device_key = self.issuer_signed.issuer_auth.device_key()?;
+        let device_key = self.issuer_signed.device_key()?;
 
         self.device_signed
             .verify_signature(
@@ -309,6 +309,12 @@ impl IssuerSigned {
             .as_ref()
             .map(IssuerNameSpaces::claims)
             .unwrap_or_else(|| BorrowedClaims(HashMap::new()))
+    }
+
+    /// Returns the signed [`DeviceKey`] of the respective `mdoc` Device the
+    /// credential is issued to.
+    pub fn device_key(&self) -> Result<DeviceKey> {
+        self.issuer_auth.device_key()
     }
 
     /// Verifies the issuer's signature of the underlying [`IssuerAuth`].


### PR DESCRIPTION
While calling `present` on the `mdoc` `Device`, the public key of the provided Device `Signer` **MUST** match the `DeviceKey` signed by the Issuer.

This forbids presenting `mdoc` credentials where the Device signature would be invalid.

Fixes: #23