### PR TITLE
Update `JsonNodePathSegment` handling.

### DIFF
--- a/bh-sd-jwt/CHANGELOG.md
+++ b/bh-sd-jwt/CHANGELOG.md
@@ -8,7 +8,7 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
-## [0.1.1] - 2025-06-17
+## [0.2.0] - 2025-06-17
 
 ### Changed
 

--- a/bh-sd-jwt/CHANGELOG.md
+++ b/bh-sd-jwt/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-06-17
+
+### Changed
+
+- Updated `JsonNodePathSegment` handling to use the `$.node1.node2`
+  path format instead of the previous `$['node1']['node2']` format.
+  This change was made to align with third-party holders,
+  who use the dot notation format.
+
 ## [0.1.0] - 2025-06-10
 
 ### Added

--- a/bh-sd-jwt/Cargo.toml
+++ b/bh-sd-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh-sd-jwt"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for handling SD-JWT specification."

--- a/bh-sd-jwt/Cargo.toml
+++ b/bh-sd-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh-sd-jwt"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for handling SD-JWT specification."

--- a/bh-sd-jwt/src/encoder.rs
+++ b/bh-sd-jwt/src/encoder.rs
@@ -576,7 +576,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             error,
-            IssuerError::NonExistentPath("$['address']['non_existent_key']".to_string())
+            IssuerError::NonExistentPath("$.address.non_existent_key".to_string())
         );
     }
 
@@ -601,7 +601,7 @@ pub(crate) mod tests {
 
         assert_eq!(
             encoder_conceal(claims, salts_and_paths).unwrap_err().error,
-            IssuerError::NonExistentPath("$['address'][3]".to_string())
+            IssuerError::NonExistentPath("$.address[3]".to_string())
         );
     }
 
@@ -672,7 +672,7 @@ pub(crate) mod tests {
         .unwrap_err()
         .error;
 
-        assert_eq!(error, IssuerError::DuplicatePath("$['sub']".to_string()));
+        assert_eq!(error, IssuerError::DuplicatePath("$.sub".to_string()));
     }
 
     #[test]

--- a/bh-sd-jwt/src/models/path.rs
+++ b/bh-sd-jwt/src/models/path.rs
@@ -80,8 +80,9 @@ impl std::fmt::Display for DisplayWrapper<'_, JsonNodePath<'_>> {
         write!(f, "$")?;
         for segment in self.0 {
             match segment {
-                // we use `['{}']` format instead of `.{}` so we can support keys that contain dots
-                JsonNodePathSegment::Key(key) => write!(f, "['{}']", key)?,
+                // Use `.{}` to conform to third-party expectations.
+                // Note: this approach does not support keys that contain dots.
+                JsonNodePathSegment::Key(key) => write!(f, ".{}", key)?,
                 JsonNodePathSegment::Index(index) => write!(f, "[{}]", index)?,
             }
         }


### PR DESCRIPTION
Use the `$.node1.node2` path format instead
of the previous `$['node1']['node2']` format.
This change was made to align with third-party holders, 
who use the dot notation format.