### PR TITLE
Fix warnings introduced by 1.89.0 accross crates

### DIFF
--- a/bh-sd-jwt/src/key_binding.rs
+++ b/bh-sd-jwt/src/key_binding.rs
@@ -273,7 +273,7 @@ impl KBJwt<jwt::token::Verified> {
     fn get_signature_verifier<'a>(
         kb_jwt: &str,
         get_signature_verifier: impl FnOnce(SigningAlgorithm) -> Option<&'a dyn SignatureVerifier>,
-    ) -> Result<(KBJwtUnverified, &'a dyn SignatureVerifier), KBError> {
+    ) -> Result<(KBJwtUnverified<'_>, &'a dyn SignatureVerifier), KBError> {
         // Despite the documentation of `jwt::Token::parse_unverified`
         // (rightfully) not recommending using it (to prevent reading the
         // contents without prior verification), we need to do this in order to

--- a/bh-sd-jwt/src/models.rs
+++ b/bh-sd-jwt/src/models.rs
@@ -184,7 +184,7 @@ impl SdJwtUnverified<'_> {
 
 impl crate::SdJwt {
     /// Further parse the SD-JWT's JWT and disclosures into a to-be-verified form.
-    pub(crate) fn parse(&self) -> Result<SdJwtUnverified, FormatError> {
+    pub(crate) fn parse(&self) -> Result<SdJwtUnverified<'_>, FormatError> {
         // Despite the documentation of `jwt::Token::parse_unverified`
         // (rightfully) not recommending using it (to prevent reading the
         // contents without prior verification), we need to do this in order to
@@ -286,7 +286,7 @@ impl SdJwtDecoded {
     }
 
     /// Pre-computed map from disclosure path in the reconstructed model to disclosure
-    pub(crate) fn disclosures_by_path(&self) -> &DisclosureByPathTable {
+    pub(crate) fn disclosures_by_path(&self) -> &DisclosureByPathTable<'_> {
         self.disclosures_by_path.get()
     }
 

--- a/bhmdoc/src/device.rs
+++ b/bhmdoc/src/device.rs
@@ -189,7 +189,7 @@ impl Device {
     }
 
     /// Extracts and returns the [`BorrowedClaims`].
-    pub fn claims(&self) -> (&DocType, BorrowedClaims) {
+    pub fn claims(&self) -> (&DocType, BorrowedClaims<'_>) {
         (&self.doc_type, self.issuer_signed.claims())
     }
 

--- a/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
+++ b/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
@@ -304,7 +304,7 @@ impl IssuerSigned {
     }
 
     /// Extracts and returns the [`BorrowedClaims`].
-    pub fn claims(&self) -> BorrowedClaims {
+    pub fn claims(&self) -> BorrowedClaims<'_> {
         self.name_spaces
             .as_ref()
             .map(IssuerNameSpaces::claims)
@@ -379,7 +379,7 @@ impl IssuerNameSpaces {
     }
 
     /// Extracts and returns the [`BorrowedClaims`].
-    fn claims(&self) -> BorrowedClaims {
+    fn claims(&self) -> BorrowedClaims<'_> {
         BorrowedClaims(
             self.0
                 .iter()
@@ -590,7 +590,7 @@ impl DeviceSigned {
     }
 
     /// Extracts and returns the [`BorrowedClaims`].
-    pub fn claims(&self) -> BorrowedClaims {
+    pub fn claims(&self) -> BorrowedClaims<'_> {
         self.name_spaces.0.inner.claims()
     }
 
@@ -654,7 +654,7 @@ impl DeviceNameSpaces {
     }
 
     /// Extracts and returns the [`BorrowedClaims`].
-    pub fn claims(&self) -> BorrowedClaims {
+    pub fn claims(&self) -> BorrowedClaims<'_> {
         BorrowedClaims(
             self.0
                 .iter()


### PR DESCRIPTION
This commit fixes the lints introduced by the latest stable Rust version (1.89.0) that got upgraded to hard errors by our CI workflow.

This commit violates our usual guideline to avoid cross-crate commits out of necessity.

Fixes: #63