### PR TITLE
`bhmdoc`: Publicly expose `ValidityInfo`

### DIFF
--- a/bhmdoc/CHANGELOG.md
+++ b/bhmdoc/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+### Added
+
+- The `ValidityInfo` is now publicly exposed, along with all its
+  properties.
+- The `Device` now has a public `validity_info` method that fetches the
+  `ValidityInfo` of the contained credential.
+
 ## [0.2.0] - 2025-04-24
 
 ### Added

--- a/bhmdoc/CHANGELOG.md
+++ b/bhmdoc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-09-08
+
 ### Added
 
 - The `ValidityInfo` is now publicly exposed, along with all its
@@ -33,6 +35,7 @@ the Issuer.
 - README.md describing the crate.
 - Initial version of the `bhmdoc` crate.
 
-[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bhmdoc/v0.2.0...HEAD>
+[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bhmdoc/v0.2.1...HEAD>
+[0.2.1]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bhmdoc/v0.2.1>
 [0.2.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bhmdoc/v0.2.0>
 [0.1.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bhmdoc/v0.1.0>

--- a/bhmdoc/Cargo.toml
+++ b/bhmdoc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bhmdoc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for handling mDL/mdoc specification."

--- a/bhmdoc/examples/full_flow.rs
+++ b/bhmdoc/examples/full_flow.rs
@@ -116,6 +116,9 @@ fn main() {
     )
     .unwrap();
 
+    // Check that Validity info exists.
+    let _ = device.validity_info().expect("Validity info should exist");
+
     // Build the `DocRequest` that contains a collection of claims that the
     // device will present to the verifier.
     // We do not need to request all claims, only the ones we are interested in.

--- a/bhmdoc/src/device.rs
+++ b/bhmdoc/src/device.rs
@@ -23,6 +23,7 @@ use crate::{
         data_retrieval::{
             common::DocType,
             device_retrieval::{
+                issuer_auth::ValidityInfo,
                 request::DeviceRequest,
                 response::{DeviceSigned, Document, IssuerNameSpaces, IssuerSigned},
             },
@@ -191,6 +192,11 @@ impl Device {
     /// Extracts and returns the [`BorrowedClaims`].
     pub fn claims(&self) -> (&DocType, BorrowedClaims<'_>) {
         (&self.doc_type, self.issuer_signed.claims())
+    }
+
+    /// Returns the [`ValidityInfo`] of the underlying credential.
+    pub fn validity_info(&self) -> Result<ValidityInfo> {
+        self.issuer_signed.issuer_auth.validity_info()
     }
 
     /// Verify that the [`DeviceKey`] signed by the `mdoc` Issuer matches the

--- a/bhmdoc/src/models/data_retrieval/device_retrieval/issuer_auth.rs
+++ b/bhmdoc/src/models/data_retrieval/device_retrieval/issuer_auth.rs
@@ -251,6 +251,10 @@ impl IssuerAuth {
         Ok(mso.into())
     }
 
+    pub(crate) fn validity_info(&self) -> Result<ValidityInfo> {
+        Ok(self.mso()?.validity_info)
+    }
+
     /// Returns the [`DeviceKey`] from the underlying [`MobileSecurityObject`].
     pub fn device_key(&self) -> Result<DeviceKey> {
         Ok(self.mso()?.device_key_info.device_key)
@@ -666,11 +670,19 @@ pub struct KeyInfo(HashMap<i64, ciborium::Value>);
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidityInfo {
-    signed: DateTime,
-    valid_from: DateTime,
-    valid_until: DateTime,
+    /// The timestamp at which the signature was created.
+    pub signed: DateTime,
+
+    /// The timestamp before which the credential is not yet valid.
+    pub valid_from: DateTime,
+
+    /// The timestamp after which the credential is no longer valid.
+    pub valid_until: DateTime,
+
+    /// The timestamp at which the issuing authority infrastructure expects to
+    /// re-sign the credential (and potentially update data elements).
     #[serde(skip_serializing_if = "Option::is_none")]
-    expected_update: Option<DateTime>,
+    pub expected_update: Option<DateTime>,
 }
 
 impl ValidityInfo {

--- a/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
+++ b/bhmdoc/src/models/data_retrieval/device_retrieval/response.rs
@@ -211,7 +211,7 @@ pub struct DocumentError(DocType, ErrorCode);
 pub struct IssuerSigned {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) name_spaces: Option<IssuerNameSpaces>,
-    issuer_auth: IssuerAuth,
+    pub(crate) issuer_auth: IssuerAuth,
 }
 
 impl IssuerSigned {


### PR DESCRIPTION
`ValidityInfo` is now publicly exposed, along with all its properties, and can be fetched from the `Device` via new `validity_info` method.