### PR TITLE
Prepare to release `bh-status-list` v0.2.0

### DIFF
--- a/bh-status-list/CHANGELOG.md
+++ b/bh-status-list/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-09-11
+
+### Changed
+
+- The `bh-jws-utils` dependency is bumped to version `0.5` (from `0.3`).
+
 ## [0.1.0] - 2025-05-08
 
 ### Added
@@ -18,5 +24,6 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 - Initial version of the `bh-status-list` crate.
 
 
-[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bh-status-list/v0.1.0...HEAD>
+[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bh-status-list/v0.2.0...HEAD>
+[0.2.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-status-list/v0.2.0>
 [0.1.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-status-list/v0.1.0>

--- a/bh-status-list/Cargo.toml
+++ b/bh-status-list/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh-status-list"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for IETF Token Status List specification."
@@ -12,7 +12,7 @@ repository = "https://github.com/blockhousetech/eudi-rust-core"
 
 [dependencies]
 base64 = "0.22"
-bh-jws-utils = "0.3"
+bh-jws-utils = "0.5"
 bherror = "0.1"
 flate2 = "1.0"
 iref = { version = "3.2", features = ["serde"] }


### PR DESCRIPTION
- The `bh-jws-utils` dependency is bumped to version `0.5` (from `0.3`).