### PR TITLE
Prepare to release `bh-sd-jwt` v0.3.0

### DIFF
--- a/bh-sd-jwt/CHANGELOG.md
+++ b/bh-sd-jwt/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-09-11
+
+### Changed
+
+- The `bh-jws-utils` dependency is bumped to version `0.5` (from `0.3`).
+- The `bh-status-list` dependency is bumped to version `0.2` (from `0.1`).
+- The `bhx5chain` dependency is bumped to version `0.3` (from `0.2`).
+
 ## [0.2.1] - 2025-09-08
 
 ### Added
@@ -33,7 +41,8 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 - README.md describing the crate.
 - Initial version of the `bh-sd-jwt` crate.
 
-[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bh-sd-jwt/v0.2.1...HEAD>
+[Unreleased]: <https://github.com/blockhousetech/eudi-rust-core/compare/bh-sd-jwt/v0.3.0...HEAD>
+[0.3.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-sd-jwt/v0.3.0>
 [0.2.1]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-sd-jwt/v0.2.1>
 [0.2.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-sd-jwt/v0.2.0>
 [0.1.0]: <https://github.com/blockhousetech/eudi-rust-core/releases/tag/bh-sd-jwt/v0.1.0>

--- a/bh-sd-jwt/Cargo.toml
+++ b/bh-sd-jwt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh-sd-jwt"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["TBTL Tech <tech@tbtl.com>"]
 categories = ["authentication", "cryptography", "encoding"]
 description = "TBTL's library for handling SD-JWT specification."
@@ -12,11 +12,11 @@ repository = "https://github.com/blockhousetech/eudi-rust-core"
 
 [dependencies]
 base64 = "0.21.7"
-bh-jws-utils = "0.3"
-bh-status-list = "0.1"
+bh-jws-utils = "0.5"
+bh-status-list = "0.2"
 bh-uri-utils = "0.1"
 bherror = "0.1"
-bhx5chain = "0.2"
+bhx5chain = "0.3"
 futures = "0.3.31"
 http = "1.1.0"
 iref = { version = "3.1.3", features = ["serde"] }
@@ -32,7 +32,7 @@ tracing = "0.1"
 yoke = { version = "0.7.4", features = ["derive"] }
 
 [dev-dependencies]
-bhx5chain = { version = "0.2", features = ["test-utils"] }
+bhx5chain = { version = "0.3", features = ["test-utils"] }
 hex = "0.4.3"
 rand = "0.8.5"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "macros"] }

--- a/bh-sd-jwt/examples/sd_jwt_vc_e2e.rs
+++ b/bh-sd-jwt/examples/sd_jwt_vc_e2e.rs
@@ -138,8 +138,11 @@ fn generate_key_pair_with_chain(
     name: &str,
     iss: Option<&UriBuf>,
 ) -> (Es256SignerWithChain, JwkPublic) {
-    let signer =
-        Es256SignerWithChain::generate(kid.to_owned(), iss, &bhx5chain::Builder::dummy()).unwrap();
+    let signer = Es256Signer::generate(kid.to_owned()).unwrap();
+    let cert_chain = bhx5chain::Builder::dummy()
+        .generate_x5chain(&signer.public_key_pem().unwrap(), iss)
+        .unwrap();
+    let signer = Es256SignerWithChain::new(signer, cert_chain).unwrap();
     let public_jwk = signer.public_jwk().unwrap();
     println!(
         "{} public key:\n{}\n",

--- a/bh-sd-jwt/examples/simple-example.rs
+++ b/bh-sd-jwt/examples/simple-example.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use bh_jws_utils::{Es256Signer, Es256SignerWithChain, Es256Verifier, SigningAlgorithm};
+use bh_jws_utils::{Es256Signer, Es256Verifier, SignerWithChain, SigningAlgorithm};
 use bh_sd_jwt::{
     holder::Holder,
     issuer::Issuer,
@@ -69,12 +69,11 @@ async fn main() {
     let iss = UriBuf::new("https://example.com/issuer".into()).unwrap();
 
     // used to sign the issued credential
-    let issuer_signer = Es256SignerWithChain::generate(
-        "issuer_kid".to_owned(),
-        Some(&iss),
-        &bhx5chain::Builder::dummy(),
-    )
-    .unwrap();
+    let issuer_signer = Es256Signer::generate("issuer_kid".to_owned()).unwrap();
+    let cert_chain = bhx5chain::Builder::dummy()
+        .generate_x5chain(&issuer_signer.public_key_pem().unwrap(), Some(&iss))
+        .unwrap();
+    let issuer_signer = SignerWithChain::new(issuer_signer, cert_chain).unwrap();
 
     // used by holder to create a cryptographic key binding
     let holder_signer = Es256Signer::generate("holder_kid".to_owned()).unwrap();


### PR DESCRIPTION
- The `bh-jws-utils` dependency is bumped to version `0.5` (from `0.3`).
- The `bh-status-list` dependency is bumped to version `0.2` (from `0.1`).
- The `bhx5chain` dependency is bumped to version `0.3` (from `0.2`).