### PR TITLE
`bh-status-list`: Add `x5c` field to `StatusListTokenHeader`

### DIFF
--- a/bh-status-list/CHANGELOG.md
+++ b/bh-status-list/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 ### Added
 
 - Added `x5c` optional field to `StatusListTokenHeader`
+- Added `StatusListTokenHeader::unverified_from_token` function
 
 ## [0.2.1] - 2026-04-01
 

--- a/bh-status-list/CHANGELOG.md
+++ b/bh-status-list/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change `kid` field in `StatusListTokenHeader` from mandatory to optional.
+
 ## [0.2.1] - 2026-04-01
 
 ### Changed

--- a/bh-status-list/CHANGELOG.md
+++ b/bh-status-list/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
 - Change `kid` field in `StatusListTokenHeader` from mandatory to optional.
 
+### Added
+
+- Added `x5c` optional field to `StatusListTokenHeader`
+
 ## [0.2.1] - 2026-04-01
 
 ### Changed

--- a/bh-status-list/Cargo.toml
+++ b/bh-status-list/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/blockhousetech/eudi-rust-core"
 base64 = "0.22"
 bh-jws-utils = "0.6"
 bherror = "0.1"
+bhx5chain = "0.3"
 flate2 = "1.0"
 iref = { version = "3.2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -21,6 +22,7 @@ serde_repr = "0.1"
 strum_macros = "0.27"
 
 [dev-dependencies]
+bhx5chain = { version = "0.3", features = ["test-utils"] }
 rand = "0.8"
 serde_json = "1.0"
 tokio-test = "0.4"

--- a/bh-status-list/src/lib.rs
+++ b/bh-status-list/src/lib.rs
@@ -95,7 +95,7 @@
 //!             status_list.status_list().clone(),
 //!         );
 //!         let status_list_token =
-//!             StatusListToken::new(status_list_claims, "example_kid".to_string(), &self.0)
+//!             StatusListToken::new(status_list_claims, Some("example_kid".to_string()), &self.0)
 //!                 .unwrap();
 //!
 //!         Ok(StatusListResponse::Jwt(

--- a/bh-status-list/src/lib.rs
+++ b/bh-status-list/src/lib.rs
@@ -95,7 +95,12 @@
 //!             status_list.status_list().clone(),
 //!         );
 //!         let status_list_token =
-//!             StatusListToken::new(status_list_claims, Some("example_kid".to_string()), &self.0)
+//!             StatusListToken::new(
+//!                 status_list_claims,
+//!                 Some("example_kid".to_string()),
+//!                 None,
+//!                 &self.0,
+//!             )
 //!                 .unwrap();
 //!
 //!         Ok(StatusListResponse::Jwt(

--- a/bh-status-list/src/status_list_token.rs
+++ b/bh-status-list/src/status_list_token.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     token,
-    utils::jwt::{sign_jwt_token, verify_jwt_token},
+    utils::jwt::{parse_jwt_token_unverified, sign_jwt_token, verify_jwt_token},
     Error, Result, StatusList, UriBuf,
 };
 
@@ -55,6 +55,8 @@ impl StatusListToken<token::Signed> {
         key: &impl JwtSigner,
     ) -> Result<Self> {
         let alg = key.algorithm();
+
+        // TODO: verify x5c leaf key is the JWT signing key
 
         let header = StatusListTokenHeader {
             alg,
@@ -166,6 +168,26 @@ pub struct StatusListTokenHeader {
 }
 
 impl StatusListTokenHeader {
+    /// Parses a Status List Token header without verifying the token
+    /// signature.
+    ///
+    /// The intended usage of this function is to call it before the `StatusListToken::verify`
+    /// function so that the caller can inspect the `kid` and `x5c` values from the header,
+    /// choose a public-key retrieval strategy, and then call the `verify` function with the
+    /// fetched key.
+    ///
+    /// The header `typ` claim is still validated to ensure the token is a
+    /// Status List Token.
+    pub fn unverified_from_token(token: &str) -> Result<StatusListTokenHeader> {
+        let token = parse_jwt_token_unverified(token)?;
+
+        token.header().verify()?;
+
+        let (header, _) = token.into();
+
+        Ok(header)
+    }
+
     /// Verifies the header of the Status List Token.
     ///
     /// The only step is checking if the `typ` claim is set to `statuslist+jwt`.
@@ -358,7 +380,7 @@ mod tests {
         let token_signed = StatusListToken::new(
             claims,
             Some("kid".to_owned()),
-            None,
+            Some(JwtX5Chain::dummy()),
             &DummySigner(alg, true),
         )
         .unwrap();
@@ -379,10 +401,14 @@ mod tests {
             status_list.into(),
         );
 
-        let err =
-            StatusListToken::new(claims, Some("kid".to_owned()), None, &DummySigner(Es512, false))
-                .err()
-                .unwrap();
+        let err = StatusListToken::new(
+            claims,
+            Some("kid".to_owned()),
+            None,
+            &DummySigner(Es512, false),
+        )
+        .err()
+        .unwrap();
 
         assert!(matches!(err.error, Error::TokenSigningFailed));
     }
@@ -400,9 +426,13 @@ mod tests {
             status_list.into(),
         );
 
-        let _token =
-            StatusListToken::new(claims, Some("kid".to_owned()), None, &DummySigner(Es256, true))
-                .unwrap();
+        let _token = StatusListToken::new(
+            claims,
+            Some("kid".to_owned()),
+            None,
+            &DummySigner(Es256, true),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -492,6 +522,23 @@ mod tests {
     }
 
     #[test]
+    fn test_status_list_token_parse_unverified_header_success() {
+        let jwt = get_valid_jwt(
+            Es256,
+            str_to_uri("http://iss"),
+            str_to_uri("http://sub"),
+            None,
+        );
+
+        let header = StatusListTokenHeader::unverified_from_token(&jwt).unwrap();
+
+        assert_eq!(header.alg, Es256);
+        assert_eq!(header.kid, Some("kid".to_owned()));
+        assert_eq!(header.x5c, Some(JwtX5Chain::dummy()));
+        assert_eq!(header.typ, STATUS_LIST_TOKEN_TYP);
+    }
+
+    #[test]
     fn test_status_list_token_verify_parse_fails() {
         let err = StatusListToken::verify(
             "invalid-token",
@@ -508,11 +555,40 @@ mod tests {
     }
 
     #[test]
+    fn test_status_list_token_parse_unverified_header_invalid_typ_fails() {
+        let status_list = StatusListInternal::new(StatusBits::Eight, None);
+        let claims = StatusListTokenClaims::new(
+            str_to_uri("http://iss"),
+            str_to_uri("http://sub"),
+            100,
+            None,
+            None,
+            status_list.into(),
+        );
+        let header = StatusListTokenHeader {
+            alg: Es256,
+            kid: Some("kid".to_owned()),
+            x5c: None,
+            typ: "not-status-list".to_owned(),
+        };
+        let jwt = sign_jwt_token(header, claims, &DummySigner(Es256, true))
+            .unwrap()
+            .as_str()
+            .to_owned();
+
+        let err = StatusListTokenHeader::unverified_from_token(&jwt)
+            .err()
+            .unwrap();
+
+        assert!(matches!(err.error, Error::InvalidTokenHeaderTyp(typ) if typ == "not-status-list"));
+    }
+
+    #[test]
     fn test_status_list_token_verify_invalid_alg_fails() {
         let iss = str_to_uri("http://iss");
         let sub = str_to_uri("http://sub");
 
-        let jwt = get_valid_jwt(Ps512, iss.clone(), sub.clone(), Option::None);
+        let jwt = get_valid_jwt(Ps512, iss.clone(), sub.clone(), None);
 
         let err = StatusListToken::verify(
             &jwt,
@@ -533,7 +609,7 @@ mod tests {
         let iss = str_to_uri("http://iss");
         let sub = str_to_uri("http://sub");
 
-        let jwt = get_valid_jwt(Ps384, iss.clone(), sub.clone(), Option::None);
+        let jwt = get_valid_jwt(Ps384, iss.clone(), sub.clone(), None);
 
         let err = StatusListToken::verify(
             &jwt,
@@ -554,7 +630,7 @@ mod tests {
         let iss = str_to_uri("http://iss");
         let sub = str_to_uri("http://sub");
 
-        let jwt = get_valid_jwt(Ps384, iss.clone(), sub.clone(), Option::None);
+        let jwt = get_valid_jwt(Ps384, iss.clone(), sub.clone(), None);
 
         let err = StatusListToken::verify(
             &jwt,
@@ -577,7 +653,7 @@ mod tests {
 
         let iss_invalid = str_to_uri("http://iss-invalid");
 
-        let jwt = get_valid_jwt(Es512, iss_invalid.clone(), sub.clone(), Option::None);
+        let jwt = get_valid_jwt(Es512, iss_invalid.clone(), sub.clone(), None);
 
         let err = StatusListToken::verify(
             &jwt,
@@ -602,7 +678,7 @@ mod tests {
 
         let sub_invalid = str_to_uri("http://sub-invalid");
 
-        let jwt = get_valid_jwt(Es256, iss.clone(), sub_invalid.clone(), Option::None);
+        let jwt = get_valid_jwt(Es256, iss.clone(), sub_invalid.clone(), None);
 
         let err = StatusListToken::verify(
             &jwt,

--- a/bh-status-list/src/status_list_token.rs
+++ b/bh-status-list/src/status_list_token.rs
@@ -37,7 +37,7 @@ impl StatusListToken<token::Signed> {
     ///
     /// The arguments are as follows:
     /// - `claims`: claims of the Status List Token,
-    /// - `kid`: an ID of the private key used to sign the token,
+    /// - `kid`: an optional ID of the private key used to sign the token,
     /// - `key`: an implementation of the algorithm used to sign the token with
     ///   the specific private key.
     ///
@@ -45,7 +45,11 @@ impl StatusListToken<token::Signed> {
     ///
     /// If the signature fails to compute, the [`Error::TokenSigningFailed`]
     /// will be returned.
-    pub fn new(claims: StatusListTokenClaims, kid: String, key: &impl JwtSigner) -> Result<Self> {
+    pub fn new(
+        claims: StatusListTokenClaims,
+        kid: Option<String>,
+        key: &impl JwtSigner,
+    ) -> Result<Self> {
         let alg = key.algorithm();
 
         let header = StatusListTokenHeader {
@@ -143,8 +147,9 @@ pub struct StatusListTokenHeader {
     /// An algorithm used to sign the token.
     pub alg: SigningAlgorithm,
 
-    /// An ID of the private key used to sign the token.
-    pub kid: String,
+    /// An optional ID of the private key used to sign the token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
 
     /// Type of the JWT, which is always _`statuslist+jwt`_.
     pub typ: String,
@@ -341,7 +346,7 @@ mod tests {
             StatusListTokenClaims::new(iss, sub, 100, exp, Option::None, status_list.into());
 
         let token_signed =
-            StatusListToken::new(claims, "kid".to_owned(), &DummySigner(alg, true)).unwrap();
+            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(alg, true)).unwrap();
 
         token_signed.to_string()
     }
@@ -359,7 +364,7 @@ mod tests {
             status_list.into(),
         );
 
-        let err = StatusListToken::new(claims, "kid".to_owned(), &DummySigner(Es512, false))
+        let err = StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es512, false))
             .err()
             .unwrap();
 
@@ -368,6 +373,24 @@ mod tests {
 
     #[test]
     fn test_status_list_token_new_success() {
+        let status_list = StatusListInternal::new(StatusBits::Two, None);
+
+        let claims = StatusListTokenClaims::new(
+            str_to_uri("http://iss"),
+            str_to_uri("http://sub"),
+            100,
+            None,
+            None,
+            status_list.into(),
+        );
+
+        let _token =
+            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es256, true))
+                .unwrap();
+    }
+
+    #[test]
+    fn test_status_list_token_new_without_kid_success() {
         let status_list = StatusListInternal::new(StatusBits::Two, Option::None);
 
         let claims = StatusListTokenClaims::new(
@@ -379,8 +402,7 @@ mod tests {
             status_list.into(),
         );
 
-        let _token =
-            StatusListToken::new(claims, "kid".to_owned(), &DummySigner(Es256, true)).unwrap();
+        let _token = StatusListToken::new(claims, None, &DummySigner(Es256, true)).unwrap();
     }
 
     #[test]
@@ -401,7 +423,8 @@ mod tests {
         );
 
         let token_signed =
-            StatusListToken::new(claims, "kid".to_owned(), &DummySigner(Es512, true)).unwrap();
+            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es512, true))
+                .unwrap();
 
         let token_verified = StatusListToken::verify(
             token_signed.as_str(),
@@ -416,7 +439,7 @@ mod tests {
         let (header, claims) = token_verified.into();
 
         assert_eq!(header.alg, Es512);
-        assert_eq!(header.kid, "kid");
+        assert_eq!(header.kid, Some("kid".to_owned()));
         assert_eq!(header.typ, STATUS_LIST_TOKEN_TYP);
 
         assert_eq!(claims.iss, iss);

--- a/bh-status-list/src/status_list_token.rs
+++ b/bh-status-list/src/status_list_token.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use bh_jws_utils::{jwt, JwkPublic, JwtSigner, JwtVerifier, SigningAlgorithm};
+use bhx5chain::JwtX5Chain;
 use iref::Uri;
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +39,8 @@ impl StatusListToken<token::Signed> {
     /// The arguments are as follows:
     /// - `claims`: claims of the Status List Token,
     /// - `kid`: an optional ID of the private key used to sign the token,
+    /// - `x5c`: an optional X.509 certificate chain corresponding to the key
+    ///   used to sign the token,
     /// - `key`: an implementation of the algorithm used to sign the token with
     ///   the specific private key.
     ///
@@ -48,6 +51,7 @@ impl StatusListToken<token::Signed> {
     pub fn new(
         claims: StatusListTokenClaims,
         kid: Option<String>,
+        x5c: Option<JwtX5Chain>,
         key: &impl JwtSigner,
     ) -> Result<Self> {
         let alg = key.algorithm();
@@ -55,6 +59,7 @@ impl StatusListToken<token::Signed> {
         let header = StatusListTokenHeader {
             alg,
             kid,
+            x5c,
             typ: STATUS_LIST_TOKEN_TYP.to_owned(),
         };
 
@@ -150,6 +155,11 @@ pub struct StatusListTokenHeader {
     /// An optional ID of the private key used to sign the token.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kid: Option<String>,
+
+    /// An optional X.509 certificate chain corresponding to the key used to
+    /// sign the token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x5c: Option<JwtX5Chain>,
 
     /// Type of the JWT, which is always _`statuslist+jwt`_.
     pub typ: String,
@@ -297,6 +307,7 @@ mod tests {
         json_object, BoxError,
         SigningAlgorithm::{self, *},
     };
+    use bhx5chain::JwtX5Chain;
 
     use super::*;
     use crate::{JwtError, StatusBits, StatusListInternal};
@@ -340,33 +351,38 @@ mod tests {
     }
 
     fn get_valid_jwt(alg: SigningAlgorithm, iss: UriBuf, sub: UriBuf, exp: Option<u64>) -> String {
-        let status_list = StatusListInternal::new(StatusBits::Eight, Option::None);
+        let status_list = StatusListInternal::new(StatusBits::Eight, None);
 
-        let claims =
-            StatusListTokenClaims::new(iss, sub, 100, exp, Option::None, status_list.into());
+        let claims = StatusListTokenClaims::new(iss, sub, 100, exp, None, status_list.into());
 
-        let token_signed =
-            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(alg, true)).unwrap();
+        let token_signed = StatusListToken::new(
+            claims,
+            Some("kid".to_owned()),
+            None,
+            &DummySigner(alg, true),
+        )
+        .unwrap();
 
         token_signed.to_string()
     }
 
     #[test]
     fn test_status_list_token_signing_fails() {
-        let status_list = StatusListInternal::new(StatusBits::Eight, Option::None);
+        let status_list = StatusListInternal::new(StatusBits::Eight, None);
 
         let claims = StatusListTokenClaims::new(
             str_to_uri("http://iss"),
             str_to_uri("http://sub"),
             100,
-            Option::None,
-            Option::None,
+            None,
+            None,
             status_list.into(),
         );
 
-        let err = StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es512, false))
-            .err()
-            .unwrap();
+        let err =
+            StatusListToken::new(claims, Some("kid".to_owned()), None, &DummySigner(Es512, false))
+                .err()
+                .unwrap();
 
         assert!(matches!(err.error, Error::TokenSigningFailed));
     }
@@ -385,29 +401,51 @@ mod tests {
         );
 
         let _token =
-            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es256, true))
+            StatusListToken::new(claims, Some("kid".to_owned()), None, &DummySigner(Es256, true))
                 .unwrap();
     }
 
     #[test]
     fn test_status_list_token_new_without_kid_success() {
-        let status_list = StatusListInternal::new(StatusBits::Two, Option::None);
+        let status_list = StatusListInternal::new(StatusBits::Two, None);
 
         let claims = StatusListTokenClaims::new(
             str_to_uri("http://iss"),
             str_to_uri("http://sub"),
             100,
-            Option::None,
-            Option::None,
+            None,
+            None,
             status_list.into(),
         );
 
-        let _token = StatusListToken::new(claims, None, &DummySigner(Es256, true)).unwrap();
+        let _token = StatusListToken::new(claims, None, None, &DummySigner(Es256, true)).unwrap();
+    }
+
+    #[test]
+    fn test_status_list_token_new_with_x5c_success() {
+        let status_list = StatusListInternal::new(StatusBits::Two, None);
+
+        let claims = StatusListTokenClaims::new(
+            str_to_uri("http://iss"),
+            str_to_uri("http://sub"),
+            100,
+            None,
+            None,
+            status_list.into(),
+        );
+
+        let _token = StatusListToken::new(
+            claims,
+            Some("kid".to_owned()),
+            Some(JwtX5Chain::dummy()),
+            &DummySigner(Es256, true),
+        )
+        .unwrap();
     }
 
     #[test]
     fn test_status_list_token_verify_success() {
-        let status_list = StatusListInternal::new(StatusBits::One, Option::None);
+        let status_list = StatusListInternal::new(StatusBits::One, None);
 
         let iss = str_to_uri("http://iss");
         let sub = str_to_uri("http://sub");
@@ -417,14 +455,19 @@ mod tests {
             iss.clone(),
             sub.clone(),
             iat,
-            Option::None,
-            Option::None,
+            None,
+            None,
             status_list.into(),
         );
 
-        let token_signed =
-            StatusListToken::new(claims, Some("kid".to_owned()), &DummySigner(Es512, true))
-                .unwrap();
+        let jwt_x5chain = JwtX5Chain::dummy();
+        let token_signed = StatusListToken::new(
+            claims,
+            Some("kid".to_owned()),
+            Some(jwt_x5chain.clone()),
+            &DummySigner(Es512, true),
+        )
+        .unwrap();
 
         let token_verified = StatusListToken::verify(
             token_signed.as_str(),
@@ -440,6 +483,7 @@ mod tests {
 
         assert_eq!(header.alg, Es512);
         assert_eq!(header.kid, Some("kid".to_owned()));
+        assert_eq!(header.x5c, Some(jwt_x5chain));
         assert_eq!(header.typ, STATUS_LIST_TOKEN_TYP);
 
         assert_eq!(claims.iss, iss);

--- a/bh-status-list/src/utils/jwt.rs
+++ b/bh-status-list/src/utils/jwt.rs
@@ -33,6 +33,17 @@ pub(crate) fn sign_jwt_token(
         .foreign_boxed_err(|| Error::TokenSigningFailed)
 }
 
+/// Parses the given JWT `token` without verifying its signature.
+///
+/// # Errors
+/// The function returns [`Error::TokenParsingFailed`] if it is unable to parse
+/// the JWT token.
+pub(crate) fn parse_jwt_token_unverified(
+    token: &str,
+) -> Result<jwt::Token<StatusListTokenHeader, StatusListTokenClaims, jwt::token::Unverified<'_>>> {
+    jwt::Token::parse_unverified(token).foreign_err(|| Error::TokenParsingFailed)
+}
+
 /// Verifies the signature of the given JWT `token`.
 ///
 /// # Errors
@@ -45,9 +56,7 @@ pub(crate) fn verify_jwt_token(
     verifier: &(impl JwtVerifier + ?Sized),
     public_key: &JwkPublic,
 ) -> Result<jwt::Token<StatusListTokenHeader, StatusListTokenClaims, token::Verified>> {
-    // Parse the token (without verification).
-    let unverified_token: jwt::Token<StatusListTokenHeader, StatusListTokenClaims, _> =
-        jwt::Token::parse_unverified(token).foreign_err(|| Error::TokenParsingFailed)?;
+    let unverified_token = parse_jwt_token_unverified(token)?;
 
     // Verify the JWT signature.
 


### PR DESCRIPTION
This PR is split into three commits :
-  Make `StatusListTokenHeader` `kid` field optional. The `kid` field is no longer mandatory since `x5c` field can also be used for public key information.
- Add `x5c` field to `StatusListTokenHeader`. The field is made optional, same as `kid` field. There is no restrictions on the fields. Any combination of `x5c` and `kid` fields is valid.
-  Add `StatusListToken::parse_unverified_header` function. This commit adds `StatusListToken::parse_unverified_header` function so that the caller code can use it to inspect the `kid` and `x5c` values from the `StatusListTokenHeader` choose the public-key retrieval strategy, and then call the `verify` function with the fetched key. The alternative would be to inject a signature verifier which would potentially require `async`. This extra capability avoids color-coding the `verify` function with `async`.

 